### PR TITLE
Make docker host-mounted volumes work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ COPY bootstrap.sh ./
 
 RUN touch /var/log/messages
 
-
 EXPOSE 22
 VOLUME /git/data
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# stuff from Dockerfile to allow the VOLUME to work: 
+mkdir -p /git/data \
+    && mkdir -p /git/data/keys \
+    && mkdir -p /git/data/users
+
 maybe_build_key(){
     if [ -f "/git/data/keys/ssh_host_$1_key" ]
     then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,9 @@ services:
     ports:
        - "1234:22"
     volumes:
-       - git_data:/git/data
-volumes:
-    git_data:
+       - ./git_data:/git/data
+#    entrypoint: sleep 100000000
+#volumes:
+#    git_data: 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,4 @@ services:
        - "1234:22"
     volumes:
        - ./git_data:/git/data
-#    entrypoint: sleep 100000000
-#volumes:
-#    git_data: 
-
 


### PR DESCRIPTION
In case docker host-mounted volumes are to be used, this does not work. The reason is that the Dockerfile creates some directories within /git/data, but this is a volume, meaning that when using host-mounted volumes, what was done during image creation is lost and the image fails to start. Doing the directory creation in the bootstrap shell script prevents this. 

I believe there will be no difference in other use cases, such as with the provided dockec-compose file, though I have not specifically tested that. 